### PR TITLE
Static link Kartridge SDK on macOS

### DIFF
--- a/kartridge/kartridge/project/Build.xml
+++ b/kartridge/kartridge/project/Build.xml
@@ -23,7 +23,7 @@
 		<files id="common"/>
 		
 		<lib name="lib/kartridge-sdk/Windows/kartridge-sdk-x86.lib" if="windows" />
-		<lib name="lib/kartridge-sdk/OSX/libkartridge-sdk.dylib" if="mac" />
+		<lib name="lib/kartridge-sdk/OSX/libkartridge-sdk.a" if="mac" />
 		
 		<outdir name="../ndll/${BINDIR}"/>
 		


### PR DESCRIPTION
Linking the *.dylib requires a runtime library, but linking to the static version will bake the SDK into the NDLL, which should be more convenient (and fixes the sample)